### PR TITLE
Update check_bluearc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+This is a fork of the DrD Studios BlueArc zenpack that appears abandoned. This fixes some issues with modeling.
+
+Compatible with Zenoss 3/4 (and probably 5) running against legacy BlueArc or Hitachi HNAS.

--- a/ZenPacks/DrD_Studios/BlueArc/libexec/check_bluearc.py
+++ b/ZenPacks/DrD_Studios/BlueArc/libexec/check_bluearc.py
@@ -101,7 +101,7 @@ if options.l == "filesystem":
   fsLabel = ''
   output  = '|'
   for volume in volumes.get('volumeTable').values():
-    if volume['volumeSysDriveIndex'] == options.fsindex:
+    if int(volume['volumeSysDriveIndex']) == int(float(options.fsindex)):
 
       fsLabel = volume['volumeLabel']
 


### PR DESCRIPTION
volumeSysDriveIndex is formatted 'nnnn' while options.fsindex is formatted 'nnnn.0'.  This change fixes that.  The script before would not return any disk usage information at all because the if loop would never be entered.
